### PR TITLE
Fix YAML encoding

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,8 +18,7 @@ const configYml = fs.readFileSync(
   path.join(__dirname, "fixtures/sample-config.yml"),
 );
 
-const buf = Buffer.from(configYml)
-const encodedConfigYml = buf.toString("base64");
+const encodedConfigYml = configYml.toString("base64");
 
 
 describe("Issue Assigner App", () => {


### PR DESCRIPTION
fs.readFileSync already returns a buffer. Doing `Buffer.from` seems to implicitly convert it to a string and cause the issue at https://github.com/probot/probot/issues/2030